### PR TITLE
node version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Setting up pantry
 
-pantry depends on node version 8.7.0. If you aren't using node 8.7.0, you will need to install it.
-You can use a node version manager such as [nvm](https://github.com/creationix/nvm) to install node 8.7.0
+pantry depends on node version 9.11.2. If you aren't using node 9.11.2, you will need to install it.
+You can use a node version manager such as [nvm](https://github.com/creationix/nvm) to install node 9.11.2
 if you dont' have it.
 
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 8.7.0
+    version: 9.11.2

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Tom Tornese",
     "Jason Aslakson"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Component library for America's Test Kitchen",
   "main": "./dist/index.js",
   "license": "SEE LICENSE IN LICENSE",
@@ -13,7 +13,7 @@
     "test": "gulp test"
   },
   "engines": {
-    "node": "8.7.0"
+    "node": "9.11.2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Upgrade node version - I will have to merge this one to master and push to npm before we can update atk version

NOTE: cannot upgrade to node 10.x b/c of build failures associated with `fsevents` package